### PR TITLE
Add filterable URL parser with lightweight URL object

### DIFF
--- a/components/DataLiberation/URL/URL.php
+++ b/components/DataLiberation/URL/URL.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+/**
+ * Simple URL-like value object used when the full URL parser is not available.
+ *
+ * Only a subset of the WHATWG URL interface is implemented. The public
+ * properties roughly match those from the spec and are populated directly via
+ * the constructor. The {@see URLSearchParams} object exposes basic query
+ * parameter manipulation.
+ */
+class URL {
+    public $protocol = '';
+    public $username = '';
+    public $password = '';
+    public $host = '';
+    public $hostname = '';
+    public $port = '';
+    public $pathname = '';
+    public $search = '';
+    public $hash = '';
+
+    /** @var URLSearchParams */
+    public $searchParams;
+
+    /**
+     * @param array $parts Associative array of URL components.
+     */
+    public function __construct( array $parts = [] ) {
+        foreach ( $parts as $key => $value ) {
+            $this->$key = $value;
+        }
+        $this->searchParams = new URLSearchParams( $this->search, $this );
+    }
+
+    /**
+     * Returns the URL as a string.
+     */
+    public function toString() {
+        $url = '';
+        if ( $this->protocol !== '' ) {
+            $url .= rtrim( $this->protocol, ':' ) . ':';
+        }
+        $authority = '';
+        $host      = $this->host !== '' ? $this->host : $this->hostname;
+        if ( $host !== '' ) {
+            if ( $this->username !== '' ) {
+                $authority .= $this->username;
+                if ( $this->password !== '' ) {
+                    $authority .= ':' . $this->password;
+                }
+                $authority .= '@';
+            }
+            $authority .= $host;
+        }
+        if ( $authority !== '' ) {
+            $url .= '//' . $authority;
+        }
+        $url .= $this->pathname;
+        $url .= $this->search;
+        $url .= $this->hash;
+
+        return $url;
+    }
+
+    public function __toString() {
+        return $this->toString();
+    }
+}

--- a/components/DataLiberation/URL/URLSearchParams.php
+++ b/components/DataLiberation/URL/URLSearchParams.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Minimal implementation of the URLSearchParams interface.
+ */
+class URLSearchParams implements IteratorAggregate, Countable {
+    /** @var array<string, string> */
+    private $params = [];
+    /** @var URL|null */
+    private $parent;
+
+    public function __construct( $query = '', URL $parent = null ) {
+        $this->parent = $parent;
+        $query        = ltrim( $query, '?' );
+        if ( '' !== $query ) {
+            parse_str( $query, $this->params );
+        }
+    }
+
+    public function getIterator() : ArrayIterator {
+        return new ArrayIterator( $this->params );
+    }
+
+    public function count() : int {
+        return count( $this->params );
+    }
+
+    public function get( $name ) {
+        return $this->params[ $name ] ?? null;
+    }
+
+    public function has( $name ) : bool {
+        return array_key_exists( $name, $this->params );
+    }
+
+    public function set( $name, $value ) : void {
+        $this->params[ $name ] = $value;
+        $this->update_parent();
+    }
+
+    public function delete( $name ) : void {
+        unset( $this->params[ $name ] );
+        $this->update_parent();
+    }
+
+    public function toString() : string {
+        return http_build_query( $this->params, '', '&', PHP_QUERY_RFC3986 );
+    }
+
+    public function __toString() : string {
+        return $this->toString();
+    }
+
+    private function update_parent() : void {
+        if ( $this->parent ) {
+            $query             = $this->toString();
+            $this->parent->search = '' === $query ? '' : '?' . $query;
+        }
+    }
+}

--- a/components/DataLiberation/URL/WPURL.php
+++ b/components/DataLiberation/URL/WPURL.php
@@ -2,84 +2,192 @@
 
 namespace WordPress\DataLiberation\URL;
 
-use Rowbot\URL\URL;
-
 /**
- * An abstraction to make swapping the URL parser easier later on.
- * We do not need it in the long run. It adds extra overhead of the
- * function call – let's remove it once the URL parser is decided.
+ * Wrapper around URL parsing that allows swapping the parser via filters.
  */
 class WPURL {
 
-	public static function parse( $url, $base = null ) {
-		if ( is_string( $url ) ) {
-			return URL::parse( $url, $base ) ?? false;
-		} elseif ( is_a( $url, 'Rowbot\URL\URL' ) ) {
-			return $url;
-		}
+    /**
+     * Parse a URL and return an URL-like object.
+     *
+     * A custom parser can be supplied via the `wp_url_parse` filter. When the
+     * filter returns a non-null value it is used as the parsing result.
+     *
+     * @param string|object $url  URL to parse or an existing URL-like object.
+     * @param string|null   $base Optional base URL when resolving relative URLs.
+     * @return object|false URL-like object on success, false on failure.
+     */
+    public static function parse( $url, $base = null ) {
+        // Allow custom parser to short-circuit.
+        $filtered = apply_filters( 'wp_url_parse', null, $url, $base );
+        if ( null !== $filtered ) {
+            return $filtered;
+        }
 
-		return false;
-	}
+        // Already parsed object – accept Rowbot URL or our simplified URL.
+        if ( is_object( $url ) && ( is_a( $url, '\\Rowbot\\URL\\URL' ) || is_a( $url, __NAMESPACE__ . '\\URL' ) ) ) {
+            return $url;
+        }
 
-	public static function can_parse( $url, $base = null ) {
-		return URL::canParse( $url, $base );
-	}
+        if ( class_exists( '\\Rowbot\\URL\\URL' ) ) {
+            if ( is_string( $url ) ) {
+                return \Rowbot\URL\URL::parse( $url, $base ) ?? false;
+            }
+            return false;
+        }
 
-	/**
-	 * Prepends a protocol to any matched URL without the double slash.
-	 *
-	 * Imagine we have a base URL of `https://example.com` and a text like `Visit myblog.com`.
-	 * This Processor would match `myblog.com` as a URL candidate and then the parser
-	 * would parse it as `https://example.com/myblog.com`, which is not what a user would expect.
-	 *
-	 * To get `https://myblog.com`, we need to prepend a protocol and turn that candidate into
-	 * `https://myblog.com` before parsing.
-	 */
-	public static function ensure_protocol( $raw_url, $protocol = 'https' ) {
-		if ( ! self::has_double_slash( $raw_url ) ) {
-			$raw_url = $protocol . '://' . $raw_url;
-		}
+        if ( ! is_string( $url ) ) {
+            return false;
+        }
 
-		return $raw_url;
-	}
+        if ( $base && is_string( $base ) ) {
+            $url = self::resolve_relative( $url, $base );
+        }
 
-	/**
-	 * This method only considers http and https protocols.
-	 */
-	public static function has_double_slash( $raw_url ) {
-		return (
-			(
-				// Protocol-relative URLs.
-				strlen( $raw_url ) > 2 &&
-				'/' === $raw_url[0] &&
-				'/' === $raw_url[1]
-			) || (
-				strlen( $raw_url ) > 7 &&
-				( 'h' === $raw_url[0] || 'H' === $raw_url[0] ) &&
-				( 't' === $raw_url[1] || 'T' === $raw_url[1] ) &&
-				( 't' === $raw_url[2] || 'T' === $raw_url[2] ) &&
-				( 'p' === $raw_url[3] || 'P' === $raw_url[3] ) &&
-				':' === $raw_url[4] &&
-				'/' === $raw_url[5] &&
-				'/' === $raw_url[6]
-			) || (
-				strlen( $raw_url ) > 8 &&
-				( 'h' === $raw_url[0] || 'H' === $raw_url[0] ) &&
-				( 't' === $raw_url[1] || 'T' === $raw_url[1] ) &&
-				( 't' === $raw_url[2] || 'T' === $raw_url[2] ) &&
-				( 'p' === $raw_url[3] || 'P' === $raw_url[3] ) &&
-				( 's' === $raw_url[4] || 'S' === $raw_url[4] ) &&
-				':' === $raw_url[5] &&
-				'/' === $raw_url[6] &&
-				'/' === $raw_url[7]
-			)
-		);
-	}
+        $parts = parse_url( $url );
+        if ( false === $parts ) {
+            return false;
+        }
 
-	public static function append_path( $base_url, $path ) {
-		$base_url           = self::parse( $base_url );
-		$base_url->pathname = rtrim( $base_url->pathname, '/' ) . '/' . ltrim( $path, '/' );
+        $hostname = $parts['host'] ?? '';
+        $port     = isset( $parts['port'] ) ? (string) $parts['port'] : '';
+        $host     = $hostname;
+        if ( $port !== '' ) {
+            $host .= ':' . $port;
+        }
 
-		return $base_url->toString();
-	}
+        return new URL( [
+            'protocol' => isset( $parts['scheme'] ) ? $parts['scheme'] . ':' : '',
+            'username' => $parts['user'] ?? '',
+            'password' => $parts['pass'] ?? '',
+            'host'     => $host,
+            'hostname' => $hostname,
+            'port'     => $port,
+            'pathname' => $parts['path'] ?? '',
+            'search'   => isset( $parts['query'] ) ? '?' . $parts['query'] : '',
+            'hash'     => isset( $parts['fragment'] ) ? '#' . $parts['fragment'] : '',
+        ] );
+    }
+
+    /**
+     * Determine whether the given URL can be parsed.
+     */
+    public static function can_parse( $url, $base = null ) {
+        $filtered = apply_filters( 'wp_url_can_parse', null, $url, $base );
+        if ( null !== $filtered ) {
+            return (bool) $filtered;
+        }
+
+        if ( class_exists( '\\Rowbot\\URL\\URL' ) ) {
+            return \Rowbot\URL\URL::canParse( $url, $base );
+        }
+
+        if ( ! is_string( $url ) ) {
+            return false;
+        }
+
+        if ( $base && is_string( $base ) ) {
+            $url = self::resolve_relative( $url, $base );
+        }
+
+        return false !== parse_url( $url );
+    }
+
+    /**
+     * Resolve a relative URL against a base URL using a very small subset of
+     * the WHATWG URL algorithm.
+     */
+    private static function resolve_relative( $url, $base ) {
+        if ( preg_match( '#^[a-zA-Z][a-zA-Z0-9+.-]*:#', $url ) ) {
+            return $url; // Already absolute.
+        }
+
+        $base_parts = parse_url( $base );
+        if ( false === $base_parts ) {
+            return $url;
+        }
+
+        $scheme   = isset( $base_parts['scheme'] ) ? $base_parts['scheme'] . '://' : '';
+        $host     = $base_parts['host'] ?? '';
+        $port     = isset( $base_parts['port'] ) ? ':' . $base_parts['port'] : '';
+        $auth     = '';
+        if ( isset( $base_parts['user'] ) ) {
+            $auth = $base_parts['user'];
+            if ( isset( $base_parts['pass'] ) ) {
+                $auth .= ':' . $base_parts['pass'];
+            }
+            $auth .= '@';
+        }
+        $authority = $scheme . $auth . $host . $port;
+
+        if ( strpos( $url, '//' ) === 0 ) {
+            return $scheme . substr( $url, 2 );
+        }
+
+        if ( $url !== '' && $url[0] === '/' ) {
+            return $authority . $url;
+        }
+
+        $path = $base_parts['path'] ?? '';
+        $path = preg_replace( '#/[^/]*$#', '/', $path );
+        return $authority . $path . $url;
+    }
+
+    /**
+     * Prepends a protocol to any matched URL without the double slash.
+     *
+     * Imagine we have a base URL of `https://example.com` and a text like `Visit myblog.com`.
+     * This Processor would match `myblog.com` as a URL candidate and then the parser
+     * would parse it as `https://example.com/myblog.com`, which is not what a user would expect.
+     *
+     * To get `https://myblog.com`, we need to prepend a protocol and turn that candidate into
+     * `https://myblog.com` before parsing.
+     */
+    public static function ensure_protocol( $raw_url, $protocol = 'https' ) {
+        if ( ! self::has_double_slash( $raw_url ) ) {
+            $raw_url = $protocol . '://' . $raw_url;
+        }
+
+        return $raw_url;
+    }
+
+    /**
+     * This method only considers http and https protocols.
+     */
+    public static function has_double_slash( $raw_url ) {
+        return (
+            (
+                // Protocol-relative URLs.
+                strlen( $raw_url ) > 2 &&
+                '/' === $raw_url[0] &&
+                '/' === $raw_url[1]
+            ) || (
+                strlen( $raw_url ) > 7 &&
+                ( 'h' === $raw_url[0] || 'H' === $raw_url[0] ) &&
+                ( 't' === $raw_url[1] || 'T' === $raw_url[1] ) &&
+                ( 't' === $raw_url[2] || 'T' === $raw_url[2] ) &&
+                ( 'p' === $raw_url[3] || 'P' === $raw_url[3] ) &&
+                ':' === $raw_url[4] &&
+                '/' === $raw_url[5] &&
+                '/' === $raw_url[6]
+            ) || (
+                strlen( $raw_url ) > 8 &&
+                ( 'h' === $raw_url[0] || 'H' === $raw_url[0] ) &&
+                ( 't' === $raw_url[1] || 'T' === $raw_url[1] ) &&
+                ( 't' === $raw_url[2] || 'T' === $raw_url[2] ) &&
+                ( 'p' === $raw_url[3] || 'P' === $raw_url[3] ) &&
+                ( 's' === $raw_url[4] || 'S' === $raw_url[4] ) &&
+                ':' === $raw_url[5] &&
+                '/' === $raw_url[6] &&
+                '/' === $raw_url[7]
+            )
+        );
+    }
+
+    public static function append_path( $base_url, $path ) {
+        $base_url           = self::parse( $base_url );
+        $base_url->pathname = rtrim( $base_url->pathname, '/' ) . '/' . ltrim( $path, '/' );
+
+        return $base_url->toString();
+    }
 }

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -2,33 +2,33 @@
 
 namespace WordPress\DataLiberation\URL;
 
-use Rowbot\URL\URL;
 use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
 
 
-/**
- * Migrate URLs in post content. See WPRewriteUrlsTests for
- * specific examples. TODO: A better description.
- *
- * Example:
- *
- * ```php
- * php > wp_rewrite_urls([
- *   'block_markup' => '<!-- wp:image {"src": "http://legacy-blog.com/image.jpg"} -->',
- *   'url-mapping' => [
- *     'http://legacy-blog.com' => 'https://modern-webstore.org'
- *   ]
- * ])
- * <!-- wp:image {"src":"https:\/\/modern-webstore.org\/image.jpg"} -->
- * ```
- *
- * @TODO Use a proper JSON parser and encoder to:
- * * Support UTF-16 characters
- * * Gracefully handle recoverable encoding issues
- * * Avoid changing the whitespace in the same manner as
- *   we do in WP_HTML_Tag_Processor
- */
-function wp_rewrite_urls( $options ) {
+if ( ! function_exists( __NAMESPACE__ . '\\wp_rewrite_urls' ) ) {
+       /**
+        * Migrate URLs in post content. See WPRewriteUrlsTests for
+        * specific examples. TODO: A better description.
+        *
+        * Example:
+        *
+        * ```php
+        * php > wp_rewrite_urls([
+        *   'block_markup' => '<!-- wp:image {"src": "http://legacy-blog.com/image.jpg"} -->',
+        *   'url-mapping' => [
+        *     'http://legacy-blog.com' => 'https://modern-webstore.org'
+        *   ]
+        * ])
+        * <!-- wp:image {"src":"https:\/\/modern-webstore.org\/image.jpg"} -->
+        * ```
+        *
+        * @TODO Use a proper JSON parser and encoder to:
+        * * Support UTF-16 characters
+        * * Gracefully handle recoverable encoding issues
+        * * Avoid changing the whitespace in the same manner as
+        *   we do in WP_HTML_Tag_Processor
+        */
+       function wp_rewrite_urls( $options ) {
 	if ( empty( $options['base_url'] ) ) {
 		// Use first from-url as base_url if not specified
 		$from_urls           = array_keys( $options['url-mapping'] );
@@ -55,17 +55,19 @@ function wp_rewrite_urls( $options ) {
 	}
 
 	return $p->get_updated_html();
+       }
 }
 
-/**
- * Check if a given URL matches the current site URL.
- *
- * @param  URL  $parent  The URL to check.
- * @param  string  $child  The current site URL to compare against.
- *
- * @return bool Whether the URL matches the current site URL.
- */
-function is_child_url_of( $child, $parent_url ) {
+if ( ! function_exists( __NAMESPACE__ . '\\is_child_url_of' ) ) {
+       /**
+        * Check if a given URL matches the current site URL.
+        *
+        * @param  URL  $parent  The URL to check.
+        * @param  string  $child  The current site URL to compare against.
+        *
+        * @return bool Whether the URL matches the current site URL.
+        */
+       function is_child_url_of( $child, $parent_url ) {
 	$parent_url                       = is_string( $parent_url ) ? WPURL::parse( $parent_url ) : $parent_url;
 	$child                            = is_string( $child ) ? WPURL::parse( $child ) : $child;
 	$child_pathname_no_trailing_slash = rtrim( urldecode( $child->pathname ), '/' );
@@ -91,20 +93,22 @@ function is_child_url_of( $child, $parent_url ) {
 		// Path prefix
 		strncmp( $child_pathname_no_trailing_slash . '/', $parent_pathname, strlen( $parent_pathname ) ) === 0
 	);
+       }
 }
 
-/**
- * Decodes the first n **encoded bytes** a URL-encoded string.
- *
- * For example, `urldecode_n( '%22is 6 %3C 6?%22 – asked Achilles', 1 )` returns
- * '"is 6 %3C 6?%22 – asked Achilles' because only the first encoded byte is decoded.
- *
- * @param  string  $string  The string to decode.
- * @param  int  $decode_n  The number of bytes to decode in $input
- *
- * @return string The decoded string.
- */
-function urldecode_n( $input, $decode_n ) {
+if ( ! function_exists( __NAMESPACE__ . '\\urldecode_n' ) ) {
+       /**
+        * Decodes the first n **encoded bytes** a URL-encoded string.
+        *
+        * For example, `urldecode_n( '%22is 6 %3C 6?%22 – asked Achilles', 1 )` returns
+        * '"is 6 %3C 6?%22 – asked Achilles' because only the first encoded byte is decoded.
+        *
+        * @param  string  $string  The string to decode.
+        * @param  int  $decode_n  The number of bytes to decode in $input
+        *
+        * @return string The decoded string.
+        */
+       function urldecode_n( $input, $decode_n ) {
 	$result = '';
 	$at     = 0;
 	while ( true ) {
@@ -146,4 +150,5 @@ function urldecode_n( $input, $decode_n ) {
 	$result .= substr( $input, $at );
 
 	return $result;
+       }
 }


### PR DESCRIPTION
## Summary
- allow custom parsing via `wp_url_parse` filter with fallback to Rowbot or a simple parser
- introduce lightweight `URL` and `URLSearchParams` classes for minimal builds
- guard URL helper functions against redeclaration

## Testing
- `./vendor/bin/phpunit components/DataLiberation/Tests/WPURLTest.php`
- `composer test` *(fails: WordPress\HttpClient\Tests\CurlTransportTest::test_dns_failure)*

------
https://chatgpt.com/codex/tasks/task_e_6897d814095c8328bffe1013730aa8cb