### PR TITLE
Create PHPCBF extension for autofixing

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,7 @@
 <ruleset name="WordPressStandard">
     <description>PHP 7.2 compatibility.</description>
     <config name="testVersion" value="7.2-"/>
+    <config name="installed_paths" value="./phpcs"/>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>vendor-patched/*</exclude-pattern>
     <rule ref="PHPCompatibilityWP"/>
@@ -39,4 +40,7 @@
         <!-- "Parameter comment must end with a full stop" is such a pebble in the shoe. -->
         <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
     </rule>
+
+    <!-- Include project-specific autofixers -->
+    <rule ref="./phpcs/ToolkitStandard/ruleset.xml"/>
 </ruleset>

--- a/phpcs/ToolkitStandard/Sniffs/Commenting/FilePackageTagSniff.php
+++ b/phpcs/ToolkitStandard/Sniffs/Commenting/FilePackageTagSniff.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace ToolkitStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FilePackageTagSniff implements Sniff
+{
+    /**
+     * Package name to insert when missing.
+     * @var string
+     */
+    public $packageName = 'project';
+
+    public function register(): array
+    {
+        return [T_OPEN_TAG];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Only run once per file at the first open tag
+        if ($stackPtr !== 0 && $phpcsFile->getTokens()[$stackPtr - 1]['code'] === T_OPEN_TAG) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $next = $phpcsFile->findNext([T_WHITESPACE], $stackPtr + 1, null, true);
+
+        // If next significant token is a doc comment, treat as file header
+        if ($next !== false && $tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            $docOpen = $next;
+            $docClose = $tokens[$docOpen]['comment_closer'];
+            // Search for @package tag
+            $hasPackage = false;
+            for ($i = $docOpen; $i <= $docClose; $i++) {
+                if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG && strtolower($tokens[$i]['content']) === '@package') {
+                    $hasPackage = true;
+                    break;
+                }
+            }
+            if ($hasPackage) {
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableError(
+                'Missing @package tag in file comment',
+                $docOpen,
+                'MissingPackageTag'
+            );
+
+            if ($fix === true) {
+                // Determine indentation from the docblock
+                $indent = '';
+                $lineStartPtr = $docOpen - 1;
+                while ($lineStartPtr > 0 && $tokens[$lineStartPtr]['line'] === $tokens[$docOpen]['line']) {
+                    $lineStartPtr--;
+                }
+                $lineStartPtr++;
+                if ($tokens[$lineStartPtr]['code'] === T_WHITESPACE) {
+                    $indent = $tokens[$lineStartPtr]['content'];
+                }
+
+                $phpcsFile->fixer->beginChangeset();
+                $insert = $indent . ' * @package ' . $this->packageName . $phpcsFile->eolChar;
+                $phpcsFile->fixer->addContentBefore($docClose, $insert);
+                $phpcsFile->fixer->endChangeset();
+            }
+            return;
+        }
+
+        // No file header found; create a minimal one after the open tag
+        $fix = $phpcsFile->addFixableError(
+            'Missing @package tag in file comment',
+            $stackPtr,
+            'MissingPackageTagHeader'
+        );
+
+        if ($fix === true) {
+            $eol = $phpcsFile->eolChar;
+            $indent = '';
+            // Determine indentation of next token line
+            if ($next !== false && $tokens[$next]['column'] > 1) {
+                $indent = str_repeat(' ', $tokens[$next]['column'] - 1);
+            }
+            $phpcsFile->fixer->beginChangeset();
+            $header = '/**' . $eol
+                . ' * ' . $eol
+                . ' * @package ' . $this->packageName . $eol
+                . ' */' . $eol;
+            $phpcsFile->fixer->addContent($stackPtr, $header);
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/phpcs/ToolkitStandard/Sniffs/Commenting/FunctionThrowsTagSniff.php
+++ b/phpcs/ToolkitStandard/Sniffs/Commenting/FunctionThrowsTagSniff.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace ToolkitStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FunctionThrowsTagSniff implements Sniff
+{
+    public function register(): array
+    {
+        return [T_FUNCTION, T_CLOSURE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Find function body range
+        $opener = $tokens[$stackPtr]['scope_opener'] ?? null;
+        $closer = $tokens[$stackPtr]['scope_closer'] ?? null;
+        if ($opener === null || $closer === null) {
+            // Probably an arrow function or abstract; skip
+            return;
+        }
+
+        $hasThrow = $phpcsFile->findNext(T_THROW, $opener + 1, $closer) !== false;
+        if (!$hasThrow) {
+            return;
+        }
+
+        // Find immediate preceding docblock
+        $prev = $phpcsFile->findPrevious([T_WHITESPACE, T_ATTRIBUTE_END, T_ATTRIBUTE], $stackPtr - 1, null, true);
+        if ($prev === false || $tokens[$prev]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            // No docblock right above; do not create a new one here to avoid conflicts
+            return;
+        }
+        $docClose = $prev;
+        $docOpen = $tokens[$docClose]['comment_opener'];
+
+        // Check if @throws is already present
+        $hasThrowsTag = false;
+        $i = $docOpen;
+        while ($i <= $docClose) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG && strtolower($tokens[$i]['content']) === '@throws') {
+                $hasThrowsTag = true;
+                break;
+            }
+            $i++;
+        }
+        if ($hasThrowsTag) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Missing @throws tag in function comment',
+            $stackPtr,
+            'MissingThrowsTag'
+        );
+
+        if ($fix === true) {
+            $indent = '';
+            // Find indentation from the docblock
+            $lineStartPtr = $docOpen - 1;
+            while ($lineStartPtr > 0 && $tokens[$lineStartPtr]['line'] === $tokens[$docOpen]['line']) {
+                $lineStartPtr--;
+            }
+            $lineStartPtr++;
+            if ($tokens[$lineStartPtr]['code'] === T_WHITESPACE) {
+                $indent = $tokens[$lineStartPtr]['content'];
+            }
+
+            $phpcsFile->fixer->beginChangeset();
+            // Insert before the closing */
+            $insert = $indent . ' * @throws \\Throwable' . $phpcsFile->eolChar;
+            $phpcsFile->fixer->addContentBefore($docClose, $insert);
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/phpcs/ToolkitStandard/Sniffs/Commenting/InlineCommentPunctuationSniff.php
+++ b/phpcs/ToolkitStandard/Sniffs/Commenting/InlineCommentPunctuationSniff.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace ToolkitStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class InlineCommentPunctuationSniff implements Sniff
+{
+    public function register(): array
+    {
+        return [T_COMMENT];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token = $tokens[$stackPtr];
+        $content = $token['content'];
+
+        // Only handle true inline comments starting with // or #
+        if (!(strpos($content, '//') === 0 || strpos($content, '#') === 0)) {
+            return;
+        }
+
+        $text = trim(ltrim($content, '/#'));
+        if ($text === '') {
+            return;
+        }
+
+        // Skip directive-like comments
+        if (stripos($text, 'phpcs:') === 0 || stripos($text, '@codingstandards') !== false) {
+            return;
+        }
+
+        $lastChar = substr($text, -1);
+        if (in_array($lastChar, ['.', '!', '?'], true)) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Inline comments must end in full-stops, exclamation marks, or question marks',
+            $stackPtr,
+            'MissingPunctuation'
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            // Preserve trailing whitespace if any
+            $trimmedRight = rtrim($content);
+            $trailing = substr($content, strlen($trimmedRight));
+            $phpcsFile->fixer->replaceToken($stackPtr, $trimmedRight . '.' . $trailing);
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/phpcs/ToolkitStandard/Sniffs/DateTime/UseGmdateSniff.php
+++ b/phpcs/ToolkitStandard/Sniffs/DateTime/UseGmdateSniff.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace ToolkitStandard\Sniffs\DateTime;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class UseGmdateSniff implements Sniff
+{
+    public function register(): array
+    {
+        return [T_STRING];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token = $tokens[$stackPtr];
+
+        if (strtolower($token['content']) !== 'date') {
+            return;
+        }
+
+        // Ensure this is a function call and not method/static
+        $next = $phpcsFile->findNext([T_WHITESPACE], $stackPtr + 1, null, true);
+        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+        $prev = $phpcsFile->findPrevious([T_WHITESPACE], $stackPtr - 1, null, true);
+        if ($prev !== false && in_array($tokens[$prev]['code'], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'date() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.',
+            $stackPtr,
+            'UseGmdate'
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($stackPtr, 'gmdate');
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/phpcs/ToolkitStandard/Sniffs/PHP/StrictInArraySniff.php
+++ b/phpcs/ToolkitStandard/Sniffs/PHP/StrictInArraySniff.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace ToolkitStandard\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class StrictInArraySniff implements Sniff
+{
+    public function register(): array
+    {
+        return [T_STRING];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token = $tokens[$stackPtr];
+
+        if (strtolower($token['content']) !== 'in_array') {
+            return;
+        }
+
+        // Ensure this is a function call (next non-whitespace must be open parenthesis)
+        $next = $phpcsFile->findNext([T_WHITESPACE], $stackPtr + 1, null, true);
+        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        // Ignore method or static calls like $obj->in_array() or Class::in_array()
+        $prev = $phpcsFile->findPrevious([T_WHITESPACE], $stackPtr - 1, null, true);
+        if ($prev !== false && in_array($tokens[$prev]['code'], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            return;
+        }
+
+        $open = $next;
+        $close = $tokens[$open]['parenthesis_closer'] ?? null;
+        if ($close === null) {
+            return;
+        }
+
+        // Count top-level commas to determine number of arguments
+        $commaCount = 0;
+        $depth = 0;
+        for ($i = $open + 1; $i < $close; $i++) {
+            $code = $tokens[$i]['code'];
+            if (in_array($code, [T_OPEN_PARENTHESIS, T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET], true)) {
+                $depth++;
+            } elseif (in_array($code, [T_CLOSE_PARENTHESIS, T_CLOSE_SHORT_ARRAY, T_CLOSE_SQUARE_BRACKET], true)) {
+                $depth--;
+            } elseif ($code === T_COMMA && $depth === 0) {
+                $commaCount++;
+            }
+        }
+
+        // If already has 3+ args, do nothing
+        if ($commaCount >= 2) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Not using strict comparison for in_array; supply true for $strict argument',
+            $stackPtr,
+            'MissingStrict'
+        );
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            $insertAt = $close; // before closing parenthesis
+            $beforeClose = $phpcsFile->findPrevious([T_WHITESPACE], $close - 1, $open + 1, false);
+            if ($beforeClose !== false && $tokens[$beforeClose]['content'] === ',') {
+                // Trailing comma style is unusual for calls; just append true
+                $phpcsFile->fixer->addContentBefore($close, ' true');
+            } else {
+                $phpcsFile->fixer->addContentBefore($close, ', true');
+            }
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/phpcs/ToolkitStandard/ruleset.xml
+++ b/phpcs/ToolkitStandard/ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="ToolkitStandard">
+    <description>Project-specific autofixers for common issues.</description>
+
+    <rule ref="ToolkitStandard.Commenting.InlineCommentPunctuation"/>
+    <rule ref="ToolkitStandard.PHP.StrictInArray"/>
+    <rule ref="ToolkitStandard.DateTime.UseGmdate"/>
+    <rule ref="ToolkitStandard.Commenting.FunctionThrowsTag"/>
+    <rule ref="ToolkitStandard.Commenting.FilePackageTag">
+        <properties>
+            <property name="packageName" value="wordpress/php-toolkit"/>
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Add a custom PHP_CodeSniffer standard with autofixers for common coding style and best practice issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8252c82-c55c-47c0-8b9e-66d5c162ab26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8252c82-c55c-47c0-8b9e-66d5c162ab26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

