### PR TITLE
chore: install monorepo builder globally

### DIFF
--- a/.github/workflows/release-composer-packages.yml
+++ b/.github/workflows/release-composer-packages.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Install Monorepo Builder
+        run: composer global require symplify/monorepo-builder:^12.2
+
       - name: Configure Git user
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -43,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          vendor/bin/monorepo-builder release ${{ github.event.inputs.bump }} --no-interaction --push-tags
+          $(composer global config bin-dir --absolute)/monorepo-builder release ${{ github.event.inputs.bump }} --no-interaction --push-tags
 
       - name: Ensure GitHub CLI and jq are installed
         run: |

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "slevomat/coding-standard": "^8.21.1",
         "wp-coding-standards/wpcs": "^3.2.0",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.0",
-        "symplify/monorepo-builder": "^9.4"
+        "phpstan/phpstan": "^1.0"
     },
     "autoload": {
         "exclude-from-classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6285ae7dea77d3b2f0ed2edf7adb5486",
+    "content-hash": "6049e854fd8e985d5ad905e3efd70567",
     "packages": [],
     "packages-dev": [
         {
@@ -2337,47 +2337,6 @@
                 }
             ],
             "time": "2025-09-05T06:01:21+00:00"
-        },
-        {
-            "name": "symplify/monorepo-builder",
-            "version": "9.4.70",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symplify/monorepo-builder.git",
-                "reference": "49260ac962cbeadb1670adc115c3dbe80abdd2b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symplify/monorepo-builder/zipball/49260ac962cbeadb1670adc115c3dbe80abdd2b1",
-                "reference": "49260ac962cbeadb1670adc115c3dbe80abdd2b1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "bin": [
-                "bin/monorepo-builder"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Prefixed version of Not only Composer tools to build a Monorepo.",
-            "support": {
-                "source": "https://github.com/symplify/monorepo-builder/tree/9.4.70"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.me/rectorphp",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-10-02T16:07:18+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
## Summary
- remove symplify/monorepo-builder dev dependency
- install monorepo-builder globally in release workflow

## Testing
- `composer test` *(fails: WordPress\HttpClient\Tests\CurlTransportTest::test_dns_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68be139e7b0c8328a90997aaf8e40163