### PR TITLE
Refactor attachment downloader events and cleanup fds

### DIFF
--- a/components/DataLiberation/Importer/class-attachmentdownloader.php
+++ b/components/DataLiberation/Importer/class-attachmentdownloader.php
@@ -10,19 +10,18 @@ use WordPress\HttpClient\Request;
 use function WordPress\Filesystem\wp_join_unix_paths;
 
 class AttachmentDownloader {
-	private $client;
-	private $fps = array();
-	private $output_root;
-	private $output_paths = array();
+        private $client;
+        private $fps = array();
+        private $output_root;
+        private $output_paths = array();
 	/**
 	 * @var Filesystem
 	 */
 	private $source_from_filesystem;
 
-	private $current_event;
-	private $pending_events = array();
-	private $enqueued_url;
-	private $progress = array();
+        private $pending_events = array();
+        private $enqueued_url;
+        private $progress = array();
 
 	public function __construct( $output_root, $options = array() ) {
 		$this->client                 = new Client();
@@ -147,24 +146,21 @@ class AttachmentDownloader {
 		return $this->enqueued_url;
 	}
 
-	public function queue_full() {
-		return count( $this->client->get_active_requests() ) >= 10;
-	}
+        public function queue_full() {
+                return count( $this->client->get_active_requests() ) >= 10;
+        }
 
-	public function get_event() {
-		return $this->current_event;
-	}
+        /**
+         * Returns the pending events and clears the internal queue.
+         *
+         * @return AttachmentDownloaderEvent[]
+         */
+        public function get_events() {
+                $events               = $this->pending_events;
+                $this->pending_events = array();
 
-	public function next_event() {
-		$this->current_event = null;
-		if ( 0 === count( $this->pending_events ) ) {
-			return false;
-		}
-
-		$this->current_event = array_shift( $this->pending_events );
-
-		return true;
-	}
+                return $events;
+        }
 
 	public function poll() {
 		while ( $this->client->await_next_event() ) {
@@ -230,14 +226,15 @@ class AttachmentDownloader {
 		return false;
 	}
 
-	private function on_failure( $original_url, $original_request_id, $error = null ) {
-		if ( isset( $this->fps[ $original_request_id ] ) ) {
-			fclose( $this->fps[ $original_request_id ] );
-		}
-		if ( isset( $this->output_paths[ $original_request_id ] ) ) {
-			$partial_file = $this->output_paths[ $original_request_id ] . '.partial';
-			if ( file_exists( $partial_file ) ) {
-				unlink( $partial_file );
+        private function on_failure( $original_url, $original_request_id, $error = null ) {
+                if ( isset( $this->fps[ $original_request_id ] ) ) {
+                        fclose( $this->fps[ $original_request_id ] );
+                        unset( $this->fps[ $original_request_id ] );
+                }
+                if ( isset( $this->output_paths[ $original_request_id ] ) ) {
+                        $partial_file = $this->output_paths[ $original_request_id ] . '.partial';
+                        if ( file_exists( $partial_file ) ) {
+                                unlink( $partial_file );
 			}
 		}
 		$this->pending_events[] = new AttachmentDownloaderEvent(
@@ -249,24 +246,34 @@ class AttachmentDownloader {
 		unset( $this->output_paths[ $original_request_id ] );
 	}
 
-	private function on_success( $original_url, $original_request_id ) {
-		// Only clean up if this was the last request in the chain.
-		if ( isset( $this->fps[ $original_request_id ] ) ) {
-			fclose( $this->fps[ $original_request_id ] );
-		}
-		if ( isset( $this->output_paths[ $original_request_id ] ) ) {
-			if ( false === rename(
-				$this->output_paths[ $original_request_id ] . '.partial',
-				$this->output_paths[ $original_request_id ]
-			) ) {
-				// @TODO: Log an error.
-			}
-		}
-		$this->pending_events[] = new AttachmentDownloaderEvent(
-			$original_url,
-			AttachmentDownloaderEvent::SUCCESS
-		);
-		unset( $this->progress[ $original_url ] );
-		unset( $this->output_paths[ $original_request_id ] );
-	}
+        private function on_success( $original_url, $original_request_id ) {
+                // Only clean up if this was the last request in the chain.
+                if ( isset( $this->fps[ $original_request_id ] ) ) {
+                        fclose( $this->fps[ $original_request_id ] );
+                        unset( $this->fps[ $original_request_id ] );
+                }
+                if ( isset( $this->output_paths[ $original_request_id ] ) ) {
+                        if ( false === rename(
+                                $this->output_paths[ $original_request_id ] . '.partial',
+                                $this->output_paths[ $original_request_id ]
+                        ) ) {
+                                // @TODO: Log an error.
+                        }
+                }
+                $this->pending_events[] = new AttachmentDownloaderEvent(
+                        $original_url,
+                        AttachmentDownloaderEvent::SUCCESS
+                );
+                unset( $this->progress[ $original_url ] );
+                unset( $this->output_paths[ $original_request_id ] );
+        }
+
+        public function __destruct() {
+                foreach ( $this->fps as $fp ) {
+                        if ( is_resource( $fp ) ) {
+                                fclose( $fp );
+                        }
+                }
+                $this->fps = array();
+        }
 }

--- a/components/DataLiberation/Importer/class-streamimporter.php
+++ b/components/DataLiberation/Importer/class-streamimporter.php
@@ -594,21 +594,20 @@ class StreamImporter {
 	 * downloader will enqueue B for download and will skip C and D since
 	 * the relevant files already exist in the filesystem.
 	 */
-	protected function frontloading_advance_reentrancy_cursor() {
-		while ( $this->downloader->next_event() ) {
-			$event = $this->downloader->get_event();
-			switch ( $event->type ) {
-				case AttachmentDownloaderEvent::FAILURE:
-				case AttachmentDownloaderEvent::SUCCESS:
-				case AttachmentDownloaderEvent::IN_PROGRESS:
-				case AttachmentDownloaderEvent::ALREADY_EXISTS:
-					$this->frontloading_events[] = $event;
-					foreach ( array_keys( $this->active_downloads ) as $entity_cursor ) {
-						unset( $this->active_downloads[ $entity_cursor ][ $event->resource_id ] );
-					}
-					break;
-			}
-		}
+        protected function frontloading_advance_reentrancy_cursor() {
+                foreach ( $this->downloader->get_events() as $event ) {
+                        switch ( $event->type ) {
+                                case AttachmentDownloaderEvent::FAILURE:
+                                case AttachmentDownloaderEvent::SUCCESS:
+                                case AttachmentDownloaderEvent::IN_PROGRESS:
+                                case AttachmentDownloaderEvent::ALREADY_EXISTS:
+                                        $this->frontloading_events[] = $event;
+                                        foreach ( array_keys( $this->active_downloads ) as $entity_cursor ) {
+                                                unset( $this->active_downloads[ $entity_cursor ][ $event->resource_id ] );
+                                        }
+                                        break;
+                        }
+                }
 
 		while ( count( $this->active_downloads ) > 0 ) {
 			$oldest_download_cursor = key( $this->active_downloads );


### PR DESCRIPTION
## Summary
- simplify AttachmentDownloader event API with `get_events`
- ensure file handles are tracked and closed, adding a destructor
- update StreamImporter to consume multiple download events

## Testing
- `composer test` (fails: WordPress\HttpClient\Tests\CurlTransportTest::test_dns_failure)
- `composer lint` (fails: phpcs reported warnings and exited with code 2)


------
https://chatgpt.com/codex/tasks/task_e_68bf08892fe88328bd69f784de94a2ec